### PR TITLE
Prefix(upTo:)/Prefix(through:)

### DIFF
--- a/Sources/Parsers/Combinators/PrefixWhile.swift
+++ b/Sources/Parsers/Combinators/PrefixWhile.swift
@@ -5,12 +5,38 @@
 //  Created by Rhys Morgan on 04/07/2020.
 //
 
+import Foundation
+
 public extension Parser where Output == Substring {
 	static func prefix(while predicate: @escaping (Character) -> Bool) -> Parser {
 		Parser { str in
 			let prefix = str.prefix(while: predicate)
 			str.removeFirst(prefix.count)
 			return prefix
+		}
+	}
+
+	static func prefix(upTo substring: Substring) -> Parser {
+		Parser { input in
+			guard let endIndex = input.range(of: substring)?.lowerBound else {
+				return nil
+			}
+
+			let match = input[..<endIndex]
+			input = input[endIndex...]
+			return match
+		}
+	}
+
+	static func prefix(through substring: Substring) -> Parser {
+		Parser { input in
+			guard let endIndex = input.range(of: substring)?.upperBound else {
+				return nil
+			}
+
+			let match = input[..<endIndex]
+			input = input[endIndex...]
+			return match
 		}
 	}
 }

--- a/Tests/ParsersTests/CombinatorsTests/PrefixWhileTests.swift
+++ b/Tests/ParsersTests/CombinatorsTests/PrefixWhileTests.swift
@@ -23,6 +23,43 @@ final class PrefixWhileTests: XCTestCase {
 		XCTAssertEqual(" Hello World!", match.rest)
 	}
 
+	func testPrefixUpto_Success() {
+		let text = "---Hello World---"
+
+		let parsed = Parser.prefix(upTo: "Hello").run(text)
+
+		XCTAssertEqual("---", parsed.match)
+		XCTAssertEqual("Hello World---", parsed.rest)
+	}
+
+	func testPrefixUpto_NotFound() {
+		let text = "---Hello World---"
+
+		let parsed = Parser.prefix(upTo: "Howdy").run(text)
+		XCTAssertNil(parsed.match)
+		XCTAssertEqual(text, String(parsed.rest))
+	}
+
+	func testPrefixThrough_Success() {
+		let text = """
+		func parse(_ string: inout String) {}
+		"""
+
+		let parsed = Parser.prefix(through: "inout").run(text)
+		XCTAssertEqual("func parse(_ string: inout", parsed.match)
+		XCTAssertEqual(" String) {}", parsed.rest)
+	}
+
+	func testPrefixThrough_NotFound() {
+		let text = """
+		func parse(_ string: inout String) {}
+		"""
+
+		let parsed = Parser.prefix(through: "Int").run(text)
+		XCTAssertNil(parsed.match)
+		XCTAssertEqual(text, String(parsed.rest))
+	}
+
 	static let allTests = [
 		(testGetsNextWord, "testGetsNextWord"),
 		(testMatchEmptyWhenNoMatchFound, "testMatchEmptyWhenNoMatchFound")


### PR DESCRIPTION
Added the `Parser.prefix(upTo:)` and `Parser.prefix(through:)` parsers, along with a couple of tests